### PR TITLE
Fix after latest CSS class changes

### DIFF
--- a/src/theme/_index.scss
+++ b/src/theme/_index.scss
@@ -3,7 +3,7 @@
 }
 
 #app-mount {
-	.wrapper-3Un6-K {
+	.wrapper_edb6e0 {
 		border-radius: var(--rs-avatar-shape);
 
 		// Remove masks
@@ -16,7 +16,7 @@
 		}
 
 		// Typing indicator
-		.dots-1k2MxY circle {
+		.dots_a97068 circle {
 			cy: -8 !important;
 			&:nth-child(1) {
 				cx: -8.5 !important;
@@ -28,7 +28,7 @@
 				cx: 4 !important;
 			}
 		}
-		.mask-1y0tyc {
+		.mask__1979f {
 			& > rect[x='22'] {
 				x: 0;
 				y: 0;
@@ -41,7 +41,7 @@
 				cy: 20;
 			}
 		}
-		.pointerEvents-2KjWnj[x='14.5'] {
+		.pointerEvents__33f6a[x='14.5'] {
 			fill: rgba(0, 0, 0, 0.5) !important;
 			width: 30px;
 			height: 30px;
@@ -51,7 +51,7 @@
 
 		// Avatar shape
 		img,
-		&.avatar-AvHqJA {
+		&.avatar__6337f {
 			border-radius: var(--rs-avatar-shape);
 		}
 
@@ -62,7 +62,7 @@
 		}
 		&[style*='80px'],
 		&[style*='120px'] {
-			svg.cursorDefault-2M8ZNp rect {
+			svg.cursorDefault_e4f616 rect {
 				ry: calc(var(--rs-avatar-shape) * 3.3);
 				rx: calc(var(--rs-avatar-shape) * 3.3);
 			}
@@ -164,7 +164,7 @@
 		// Medium ring (user popout)
 		&[style*='80px'] {
 			// Updated status
-			svg.cursorDefault-2M8ZNp rect {
+			svg.cursorDefault_e4f616 rect {
 				x: -48;
 				y: -52;
 			}
@@ -184,7 +184,7 @@
 		// Large ring (user profile)
 		&[style*='120px'] {
 			// Updated status
-			svg.cursorDefault-2M8ZNp rect {
+			svg.cursorDefault_e4f616 rect {
 				x: -70;
 				y: -76;
 			}
@@ -273,10 +273,10 @@
 	}
 
 	// Bottom left avatar, speaking in VC
-	.avatarStack-3vfSFa {
+	.avatarStack__6604a {
 		position: relative;
 	}
-	.avatarSpeaking-33RRJU {
+	.avatarSpeaking__61fb1 {
 		position: absolute;
 		top: 2px;
 		left: 2px;
@@ -288,7 +288,7 @@
 	}
 
 	// Mobile and typing fix for status everywhere plugins
-	.message-2CShn3 .wrapper-3Un6-K {
+	.message__80c10 .wrapper_edb6e0 {
 		foreignObject[mask*='mobile'] {
 			width: calc(100% + 3px);
 		}
@@ -298,10 +298,10 @@
 	}
 
 	// Avatar hint
-	.avatarHint-2g3Mcd foreignObject {
+	.avatarHint__8e5b9 foreignObject {
 		mask: none;
 	}
-	.avatarHintInner-3gk_Yx {
+	.avatarHintInner__3d1c9 {
 		border-radius: var(--rs-avatar-shape) !important;
 		padding-top: 0;
 		width: calc(100% - var(--rs-medium-width) - var(--rs-medium-spacing) + 1px * 2);
@@ -316,23 +316,23 @@
 	.memberOffline-2lN7gt img {
 		clip-path: none !important;
 	}
-	.offline-22aM7E img {
+	.offline_c1fd80 img {
 		clip-path: none !important;
 	}
 
 	// Webhook popout
-	.avatarWrapperNonUserBot-3fzpUZ .wrapper-3Un6-K img {
+	.avatarWrapperNonUserBot_d27212 .wrapper_edb6e0 img {
 		clip-path: none !important;
 	}
 
 	// Fix clipping on user friends tab
-	.userInfo-2WpsYG .wrapper-3Un6-K {
+	.userInfo__18240 .wrapper_edb6e0 {
 		margin-top: 1px;
 		margin-left: 1px;
 	}
 
 	// Version info
-	.info-3pQQBb .line-18uChy:last-child:after {
+	.info__755e1 .line__75801:last-child:after {
 		content: 'RadialStatus ' var(--rs-version);
 		display: block;
 	}


### PR DESCRIPTION
Cannot figure out what `memberOffline-2lN7gt` maps to now, but otherwise I'm pretty sure I got everything? And it looks like it works fine when I test it.

Class mappings, best as I can tell (verified against [this list](https://github.com/Saltssaumure/ClassUpdate/blob/main/olddiff.txt) where possible):
```
wrapper-3Un6-K -> wrapper_edb6e0
dots-1k2MxY -> dots_a97068
mask-1y0tyc -> mask__1979f
pointerEvents-2KjWnj -> pointerEvents__33f6a
avatar-AvHqJA -> avatar__6337f
avatarHint-2g3Mcd -> avatarHint__8e5b9
avatarHintInner-3gk_Yx -> avatarHintInner__3d1c9
offline-22aM7E -> offline_c1fd80
avatarWrapperNonUserBot-3fzpUZ -> avatarWrapperNonUserBot_d27212
userInfo-2WpsYG -> userInfo__18240
info-3pQQBb -> info__755e1
line-18uChy -> line__75801
message-2CShn3 -> message__80c10
avatarStack-3vfSFa -> avatarStack__6604a
cursorDefault-2M8ZNp -> cursorDefault_e4f616
avatarSpeaking-33RRJU -> avatarSpeaking__61fb1
memberOffline-2lN7gt -> ???
```